### PR TITLE
Dummy assemble tasks to comply with android studio's gradle compilations

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -42,3 +42,7 @@ task clean << {
   ant.delete file: 'src/main/sphinx/conf.py'
 }
 
+/* Dummy task to stop android studio barfing */
+task assembleDebug {}
+task assembleRelease {}
+task assemble {}


### PR DESCRIPTION
This stops android studio from complaining when it makes the gradle superproject (effect was introduced with Android Studio 0.2.3).
