### PR TITLE
Acm serial: auto-detect ACM interface for USB device

### DIFF
--- a/android_acm_serial/build.gradle
+++ b/android_acm_serial/build.gradle
@@ -17,6 +17,7 @@
 
 dependencies {
   compile project(':android_honeycomb_mr2')
+  compile project(':android_gingerbread_mr1')
 }
 
 apply plugin: 'android-library'


### PR DESCRIPTION
I forgot to work out a CLA before pull requesting to ros-java, so setting up a pull request now back to rosjava.

@sebasgm85 if you haven't already done, can you sign a CLA for @damonkohler as described [here](https://github.com/rosjava/rosjava_core)? Then I can merge this back into the rosjava organisation.

Original notes from @sebasgm85:

This Pull Request enhances AcmDevice in the android_acm_serial library to allow auto-detection of the appropriate / compatible interface given a USB device.
Before this, the USB interface was hardcoded to the value 1, which worked for the Hokuyo tutorial but failed for other devices which used a different interface number for ACM communication.
