### PR TITLE
Change PubSub tutorial to allow communication with a remote ROS master.

### DIFF
--- a/android_tutorial_pubsub/src/org/ros/android/android_tutorial_pubsub/MainActivity.java
+++ b/android_tutorial_pubsub/src/org/ros/android/android_tutorial_pubsub/MainActivity.java
@@ -17,6 +17,7 @@
 package org.ros.android.android_tutorial_pubsub;
 
 import android.os.Bundle;
+import org.ros.address.InetAddressFactory;
 import org.ros.android.MessageCallable;
 import org.ros.android.RosActivity;
 import org.ros.android.view.RosTextView;
@@ -57,10 +58,11 @@ public class MainActivity extends RosActivity {
   @Override
   protected void init(NodeMainExecutor nodeMainExecutor) {
     talker = new Talker();
-    NodeConfiguration nodeConfiguration = NodeConfiguration.newPrivate();
     // At this point, the user has already been prompted to either enter the URI
     // of a master to use or to start a master locally.
-    nodeConfiguration.setMasterUri(getMasterUri());
+    String host = InetAddressFactory.newNonLoopback().getHostName();
+    NodeConfiguration nodeConfiguration = NodeConfiguration.newPublic(host, getMasterUri());
+
     nodeMainExecutor.execute(talker, nodeConfiguration);
     // The RosTextView is also a NodeMain that must be executed in order to
     // start displaying incoming messages.

--- a/android_tutorial_pubsub/src/org/ros/android/android_tutorial_pubsub/MainActivity.java
+++ b/android_tutorial_pubsub/src/org/ros/android/android_tutorial_pubsub/MainActivity.java
@@ -60,7 +60,7 @@ public class MainActivity extends RosActivity {
     talker = new Talker();
     // At this point, the user has already been prompted to either enter the URI
     // of a master to use or to start a master locally.
-    String host = InetAddressFactory.newNonLoopback().getHostName();
+    String host = InetAddressFactory.newNonLoopback().getHostAddress();
     NodeConfiguration nodeConfiguration = NodeConfiguration.newPublic(host, getMasterUri());
 
     nodeMainExecutor.execute(talker, nodeConfiguration);


### PR DESCRIPTION
This PR changes the init method to use newPublic instead of newPrivate.  Using newPublic with a non-loopback host enables this node to communicate bidirectionally with a remote ROS master, which I think should be allowed given the tutorial.
