### PR TITLE
List all network interfaces in master chooser

### DIFF
--- a/android_10/build.gradle
+++ b/android_10/build.gradle
@@ -15,7 +15,7 @@
  */
 
 dependencies {
-  compile 'org.ros.rosjava_core:rosjava:0.1.+'
+  compile 'org.ros.rosjava_core:rosjava:0.2.+'
   compile 'org.ros.rosjava_messages:sensor_msgs:1.10.+'
   compile 'org.ros.rosjava_messages:diagnostic_msgs:1.10.+'
 }

--- a/android_10/res/layout/master_chooser.xml
+++ b/android_10/res/layout/master_chooser.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:focusable="false"
-    style="@style/padded">
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:orientation="vertical"
+              android:focusable="false"
+              style="@style/padded">
 
     <LinearLayout
             android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            >
+            android:layout_height="fill_parent">
 
         <TextView
                 android:layout_width="wrap_content"
@@ -20,14 +19,14 @@
                 android:textSize="18dp"/>
 
         <EditText
-            android:id="@+id/master_chooser_uri"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:hint="@string/master_uri_hint"
-            android:singleLine="true"
-            android:layout_weight="20">
+                android:id="@+id/master_chooser_uri"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:hint="@string/master_uri_hint"
+                android:singleLine="true"
+                android:layout_weight="20">
 
-            <requestFocus />
+            <requestFocus/>
         </EditText>
 
     </LinearLayout>
@@ -46,12 +45,12 @@
                 android:layout_weight="1"/>
 
         <Button
-            android:id="@+id/master_chooser_ok"
-            android:layout_width="0dip"
-            android:layout_height="wrap_content"
-            android:onClick="okButtonClicked"
-            android:text="@string/use_master"
-            android:layout_weight="1"/>
+                android:id="@+id/master_chooser_ok"
+                android:layout_width="0dip"
+                android:layout_height="wrap_content"
+                android:onClick="okButtonClicked"
+                android:text="@string/use_master"
+                android:layout_weight="1"/>
     </LinearLayout>
 
     <CheckBox
@@ -64,26 +63,52 @@
             style="@style/padded"/>
 
     <LinearLayout
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent">
-
-        <Button
-            android:id="@+id/master_chooser_new_master_button"
+            android:orientation="vertical"
             android:layout_width="wrap_content"
-            android:layout_height="fill_parent"
-            android:onClick="newMasterButtonClicked"
-            android:text="@string/new_master"
-            android:layout_weight="1"
-            android:visibility="gone"/>
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            android:id="@+id/advancedOptions">
 
-        <Button
-                android:id="@+id/master_chooser_new_private_master_button"
+        <TextView
                 android:layout_width="wrap_content"
-                android:layout_height="fill_parent"
-                android:onClick="newPrivateMasterButtonClicked"
-                android:text="@string/new_private_master"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:text="@string/select_interface"
+                android:id="@+id/interfaceLabel"
+                android:layout_gravity="center"
+                android:autoText="true"/>
+
+        <ListView
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:id="@+id/networkInterfaces"
                 android:layout_weight="1"
-                android:visibility="gone"/>
+                android:visibility="visible"/>
+
+        <LinearLayout
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent">
+
+            <Button
+                    android:id="@+id/master_chooser_new_master_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="fill_parent"
+                    android:onClick="newMasterButtonClicked"
+                    android:text="@string/new_master"
+                    android:layout_weight="1"
+                    android:visibility="visible"/>
+
+            <Button
+                    android:id="@+id/master_chooser_new_private_master_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="fill_parent"
+                    android:onClick="newPrivateMasterButtonClicked"
+                    android:text="@string/new_private_master"
+                    android:layout_weight="1"
+                    android:visibility="visible"/>
+
+        </LinearLayout>
+
     </LinearLayout>
 
     <Button

--- a/android_10/res/values/common_strings.xml
+++ b/android_10/res/values/common_strings.xml
@@ -9,6 +9,7 @@
     <string name="new_master">New Public Master</string>
     <string name="new_private_master">New Private Master</string>
     <string name="show_advanced">Show advanced options</string>
+    <string name="select_interface">Select network interface</string>
     <string name="uri_text">Robot URI:</string>
 
 </resources>

--- a/android_10/src/org/ros/android/MasterChooser.java
+++ b/android_10/src/org/ros/android/MasterChooser.java
@@ -19,6 +19,7 @@ package org.ros.android;
 import com.google.common.base.Preconditions;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
@@ -26,15 +27,25 @@ import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.View;
-import android.widget.Button;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
 import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.ListView;
 import android.widget.Toast;
 import org.ros.android.android_10.R;
+import org.ros.exception.RosRuntimeException;
 import org.ros.node.NodeConfiguration;
 
+import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -63,19 +74,67 @@ public class MasterChooser extends Activity {
       "com.google.zxing.client.android.SCAN";
 
   private String masterUri;
+  private String selectedInterface;
   private EditText uriText;
+
+  private class StableArrayAdapter extends ArrayAdapter<String> {
+
+    HashMap<String, Integer> idMap = new HashMap<String, Integer>();
+
+    public StableArrayAdapter(Context context, int textViewResourceId, List<String> objects) {
+      super(context, textViewResourceId, objects);
+      for (int i = 0; i < objects.size(); ++i) {
+        idMap.put(objects.get(i), i);
+      }
+    }
+
+    @Override
+    public long getItemId(int position) {
+      String item = getItem(position);
+      return idMap.get(item);
+    }
+
+    @Override
+    public boolean hasStableIds() {
+      return true;
+    }
+  }
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.master_chooser);
     uriText = (EditText) findViewById(R.id.master_chooser_uri);
-    // Get the URI from preferences and display it. Since only primitive types
-    // can be saved in preferences the URI is stored as a string.
-    masterUri =
-        getPreferences(MODE_PRIVATE).getString(PREFS_KEY_NAME,
-            NodeConfiguration.DEFAULT_MASTER_URI.toString());
+    // Get the URI from preferences and display it. Since only primitive types can be saved in
+    // preferences the URI is stored as a string.
+    masterUri = getPreferences(MODE_PRIVATE).getString(PREFS_KEY_NAME, NodeConfiguration.DEFAULT_MASTER_URI.toString());
     uriText.setText(masterUri);
+
+    ListView interfacesList = (ListView) findViewById(R.id.networkInterfaces);
+    final List<String> list = new ArrayList<String>();
+
+    try {
+      for (NetworkInterface networkInterface : Collections.list(NetworkInterface.getNetworkInterfaces())) {
+        if (networkInterface.isUp() && !networkInterface.isLoopback()) {
+          list.add(networkInterface.getName());
+        }
+      }
+    } catch (SocketException e) {
+      throw new RosRuntimeException(e);
+    }
+
+    // Fallback to previous behaviour when no interface is selected.
+    selectedInterface = "";
+
+    final StableArrayAdapter adapter = new StableArrayAdapter(this, android.R.layout.simple_list_item_1, list);
+    interfacesList.setAdapter(adapter);
+
+    interfacesList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+      @Override
+      public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+        selectedInterface = parent.getItemAtPosition(position).toString();
+      }
+    });
   }
 
   @Override
@@ -115,9 +174,7 @@ public class MasterChooser extends Activity {
     editor.putString(PREFS_KEY_NAME, masterUri);
     editor.commit();
     // Package the intent to be consumed by the calling activity.
-    Intent intent = new Intent();
-    intent.putExtra("NEW_MASTER", false);
-    intent.putExtra("ROS_MASTER_URI", masterUri);
+    Intent intent = createNewMasterIntent(false, true);
     setResult(RESULT_OK, intent);
     finish();
   }
@@ -127,8 +184,8 @@ public class MasterChooser extends Activity {
     intent.putExtra("SCAN_MODE", "QR_CODE_MODE");
     // Check if the Barcode Scanner is installed.
     if (!isQRCodeReaderInstalled(intent)) {
-      // Open the Market and take them to the page from which they can download
-      // the Barcode Scanner app.
+      // Open the Market and take them to the page from which they can download the Barcode Scanner
+      // app.
       startActivity(new Intent(Intent.ACTION_VIEW,
           Uri.parse("market://details?id=com.google.zxing.client.android")));
     } else {
@@ -139,31 +196,30 @@ public class MasterChooser extends Activity {
 
   public void advancedCheckboxClicked(View view) {
     boolean checked = ((CheckBox) view).isChecked();
-    Button new_public_master = (Button) findViewById(R.id.master_chooser_new_master_button);
-    Button new_private_master = (Button) findViewById(R.id.master_chooser_new_private_master_button);
+    LinearLayout advancedOptions = (LinearLayout) findViewById(R.id.advancedOptions);
     if (checked) {
-      new_private_master.setVisibility(View.VISIBLE);
-      new_public_master.setVisibility(View.VISIBLE);
+      advancedOptions.setVisibility(View.VISIBLE);
     } else {
-      new_private_master.setVisibility(View.GONE);
-      new_public_master.setVisibility(View.GONE);
+      advancedOptions.setVisibility(View.GONE);
     }
   }
 
-  public Intent createNewMasterIntent (Boolean isPrivate) {
+  public Intent createNewMasterIntent(boolean newMaster, boolean isPrivate) {
     Intent intent = new Intent();
-    intent.putExtra("NEW_MASTER", true);
+    intent.putExtra("ROS_MASTER_CREATE_NEW", newMaster);
     intent.putExtra("ROS_MASTER_PRIVATE", isPrivate);
+    intent.putExtra("ROS_MASTER_URI", masterUri);
+    intent.putExtra("ROS_MASTER_NETWORK_INTERFACE", selectedInterface);
     return intent;
   }
 
   public void newMasterButtonClicked(View unused) {
-    setResult(RESULT_OK, createNewMasterIntent(false));
+    setResult(RESULT_OK, createNewMasterIntent(true, false));
     finish();
   }
 
   public void newPrivateMasterButtonClicked(View unused) {
-    setResult(RESULT_OK, createNewMasterIntent(true));
+    setResult(RESULT_OK, createNewMasterIntent(true, true));
     finish();
   }
 

--- a/android_tutorial_pubsub/src/org/ros/android/android_tutorial_pubsub/MainActivity.java
+++ b/android_tutorial_pubsub/src/org/ros/android/android_tutorial_pubsub/MainActivity.java
@@ -17,6 +17,7 @@
 package org.ros.android.android_tutorial_pubsub;
 
 import android.os.Bundle;
+
 import org.ros.android.MessageCallable;
 import org.ros.android.RosActivity;
 import org.ros.android.view.RosTextView;
@@ -57,9 +58,13 @@ public class MainActivity extends RosActivity {
   @Override
   protected void init(NodeMainExecutor nodeMainExecutor) {
     talker = new Talker();
-    NodeConfiguration nodeConfiguration = NodeConfiguration.newPrivate();
+
     // At this point, the user has already been prompted to either enter the URI
     // of a master to use or to start a master locally.
+
+    // The user can easily use the selected ROS Hostname in the master chooser
+    // activity.
+    NodeConfiguration nodeConfiguration = NodeConfiguration.newPublic(getRosHostname());
     nodeConfiguration.setMasterUri(getMasterUri());
     nodeMainExecutor.execute(talker, nodeConfiguration);
     // The RosTextView is also a NodeMain that must be executed in order to

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>android_core</name>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <description>
     Android support packages for rosjava.
   </description>


### PR DESCRIPTION
A list of detected network interfaces can be found in the advanced
options segment of the master chooser UI. Selecting an interface allows
the user to configure the ROS Hostname. If no interface is selected then
the code fall-back to the previous behaviour.

I made a simple modifications to the pubsub example to show how the
RosHostname can be used in the applications.

This pull request supersedes https://github.com/rosjava/android_core/pull/183
