### PR TITLE
Add onDoubleTap to CameraControlListener

### DIFF
--- a/android_15/src/org/ros/android/view/visualization/layer/CameraControlLayer.java
+++ b/android_15/src/org/ros/android/view/visualization/layer/CameraControlLayer.java
@@ -28,6 +28,7 @@ import org.ros.concurrent.ListenerGroup;
 import org.ros.concurrent.SignalRunnable;
 import org.ros.node.ConnectedNode;
 import org.ros.node.NodeMainExecutor;
+import org.ros.rosjava_geometry.Vector3;
 
 /**
  * Provides gesture control of the camera for translate, rotate, and zoom.
@@ -87,6 +88,20 @@ public class CameraControlLayer extends DefaultLayer {
                   @Override
                   public void run(CameraControlListener listener) {
                     listener.onTranslate(-distanceX, distanceY);
+                  }
+                });
+                return true;
+              }
+
+              @Override
+              public boolean onDoubleTap (MotionEvent e) {
+                float x = e.getX();
+                float y = e.getY();
+                final Vector3 tapVector = view.getCamera().toCameraFrame((int)x, (int)y);
+                listeners.signal(new SignalRunnable<CameraControlListener>() {
+                  @Override
+                  public void run(CameraControlListener listener) {
+                    listener.onDoubleTap(tapVector);
                   }
                 });
                 return true;

--- a/android_15/src/org/ros/android/view/visualization/layer/CameraControlListener.java
+++ b/android_15/src/org/ros/android/view/visualization/layer/CameraControlListener.java
@@ -16,6 +16,8 @@
 
 package org.ros.android.view.visualization.layer;
 
+import org.ros.rosjava_geometry.Vector3;
+
 /**
  * @author damonkohler@google.com (Damon Kohler)
  */
@@ -25,4 +27,6 @@ public interface CameraControlListener {
   void onRotate(double focusX, double focusY, double deltaAngle);
 
   void onZoom(double focusX, double focusY, double factor);
+
+  void onDoubleTap(Vector3 tap);
 }

--- a/android_tutorial_map_viewer/src/org/ros/android/android_tutorial_map_viewer/MainActivity.java
+++ b/android_tutorial_map_viewer/src/org/ros/android/android_tutorial_map_viewer/MainActivity.java
@@ -36,6 +36,7 @@ import org.ros.android.view.visualization.layer.OccupancyGridLayer;
 import org.ros.android.view.visualization.layer.RobotLayer;
 import org.ros.node.NodeConfiguration;
 import org.ros.node.NodeMainExecutor;
+import org.ros.rosjava_geometry.Vector3;
 import org.ros.time.NtpTimeProvider;
 
 import java.util.concurrent.TimeUnit;
@@ -90,6 +91,9 @@ public class MainActivity extends RosActivity {
         disableFollowMe();
       }
 
+      @Override
+      public void onDoubleTap(Vector3 tap) {
+      }
     });
     NodeConfiguration nodeConfiguration =
         NodeConfiguration.newPublic(InetAddressFactory.newNonLoopback().getHostAddress(),


### PR DESCRIPTION
The user of a visualization view can now use the double tap gesture and obtain the tapped position in the camera frame. This can be used to send nav goals by tapping the map.

Adds the onDoubleTap method to CameraControlListener. This breaks previous code that does not override that method. The map_viewer tutorial is updated in this commit.
