### PR TITLE
Upgrade for gradle wrapper 1.8-1.9 and android plugin 0.6.1-0.7.1

### DIFF
--- a/android_benchmarks/build.gradle
+++ b/android_benchmarks/build.gradle
@@ -31,4 +31,9 @@ android {
     versionCode 1
     versionName "1.0"
   }
+  packagingOptions {
+    /* https://github.com/rosjava/android_core/issues/194 */
+    exclude 'META-INF/LICENSE.txt'
+    exclude 'META-INF/NOTICE.txt'
+  }
 }

--- a/android_tutorial_camera/build.gradle
+++ b/android_tutorial_camera/build.gradle
@@ -30,4 +30,9 @@ android {
     versionCode 1
     versionName "1.0"
   }
+  packagingOptions {
+    /* https://github.com/rosjava/android_core/issues/194 */
+    exclude 'META-INF/LICENSE.txt'
+    exclude 'META-INF/NOTICE.txt'
+  }
 }

--- a/android_tutorial_image_transport/build.gradle
+++ b/android_tutorial_image_transport/build.gradle
@@ -22,7 +22,11 @@ apply plugin: 'android'
 
 android {
   compileSdkVersion 10
-
+  packagingOptions {
+    /* https://github.com/rosjava/android_core/issues/194 */
+    exclude 'META-INF/LICENSE.txt'
+    exclude 'META-INF/NOTICE.txt'
+  }
   defaultConfig {
     minSdkVersion 10
     packageName "org.ros.android.android_tutorial_image_transport"

--- a/android_tutorial_map_viewer/build.gradle
+++ b/android_tutorial_map_viewer/build.gradle
@@ -30,4 +30,9 @@ android {
     versionCode 1
     versionName "1.0"
   }
+  packagingOptions {
+    /* https://github.com/rosjava/android_core/issues/194 */
+    exclude 'META-INF/LICENSE.txt'
+    exclude 'META-INF/NOTICE.txt'
+  }
 }

--- a/android_tutorial_pubsub/build.gradle
+++ b/android_tutorial_pubsub/build.gradle
@@ -31,4 +31,9 @@ android {
     versionCode 1
     versionName "1.0"
   }
+  packagingOptions {
+    /* https://github.com/rosjava/android_core/issues/194 */
+    exclude 'META-INF/LICENSE.txt'
+    exclude 'META-INF/NOTICE.txt'
+  }
 }

--- a/android_tutorial_teleop/build.gradle
+++ b/android_tutorial_teleop/build.gradle
@@ -30,4 +30,9 @@ android {
     versionCode 1
     versionName "1.0"
   }
+  packagingOptions {
+      /* https://github.com/rosjava/android_core/issues/194 */
+      exclude 'META-INF/LICENSE.txt'
+      exclude 'META-INF/NOTICE.txt'
+  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  */
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '1.8'
+    gradleVersion = '1.9'
 }
 
 buildscript {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Oct 18 16:03:41 CEST 2013
+#Tue Dec 24 11:26:26 KST 2013
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.8-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.9-bin.zip


### PR DESCRIPTION
The new android studio sets these as a minimum requirement.

One problem with the upgrade - it now throws an error on previous bad behaviour assembling files which copy over each other for which we just workaround for now (refer to #194).
