### PR TITLE
Update gradle's Android plugin required version

### DIFF
--- a/buildscript.gradle
+++ b/buildscript.gradle
@@ -17,6 +17,6 @@
 rootProject.buildscript {
   apply from: "https://github.com/rosjava/rosjava_bootstrap/raw/indigo/buildscript.gradle"
   dependencies {
-    classpath "com.android.tools.build:gradle:0.11.+"
+    classpath "com.android.tools.build:gradle:0.12.+"
   }
 }


### PR DESCRIPTION
This change will fix android_extra and every project created using catking_create_android_xxx commands.
