### PR TITLE
changes:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(android_core)
 
 find_package(catkin REQUIRED rosjava_build_tools)
 
-catkin_android_setup(assembleRelease uploadArchives)
+catkin_android_setup(assembleRelease uploadArchives publishMavenJavaPublicationToMavenRepository)
 
 catkin_package()
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ allprojects {
     version = project.catkin.pkg.version
 }
 
-configure(subprojects.findAll { it.name.startsWith("android_") }) {
+subprojects {
     /*
      * The android plugin configures a few things:
      *
@@ -37,44 +37,50 @@ configure(subprojects.findAll { it.name.startsWith("android_") }) {
      *  - local maven repositories    : where it finds your locally installed/built artifacts)
      *  - external maven repositories : where it goes looking if it can't find dependencies locally
      *  - android build tools version : which version we use across the board
-     * 
+     *
      * To modify, or add repos to the default external maven repositories list, pull request against this code:
      *
      *   https://github.com/rosjava/rosjava_bootstrap/blob/indigo/gradle_plugins/src/main/groovy/org/ros/gradle_plugins/RosPlugin.groovy#L31
-     * 
+     *
      * To modify the build tools version, pull request against this code:
-     * 
+     *
      *   https://github.com/rosjava/rosjava_bootstrap/blob/indigo/gradle_plugins/src/main/groovy/org/ros/gradle_plugins/RosAndroid.groovy#L14
      */
-    apply plugin: "ros-android"
-    afterEvaluate { project ->
-        // Change the layout of Android projects to be compatible with Eclipse.
-        android {
-            sourceSets {
-                //noinspection GroovyAssignabilityCheck
-                main {
-                    manifest.srcFile "AndroidManifest.xml"
-                    res.srcDirs "res"
-                    assets.srcDirs "assets"
-                    java.srcDirs "src"
+    if (name != "docs" && name != "compressed_map_transport"  && name != "polling_input_stream") {
+        apply plugin: "ros-android"
+        afterEvaluate { project ->
+            // Change the layout of Android projects to be compatible with Eclipse.
+            android {
+                sourceSets {
+                    //noinspection GroovyAssignabilityCheck
+                    main {
+                        manifest.srcFile "AndroidManifest.xml"
+                        res.srcDirs "res"
+                        assets.srcDirs "assets"
+                        java.srcDirs "src"
+                    }
                 }
-            }
 
-            // Copy JAR dependencies into the libs directory for Eclipse.
-            task deployLibs(type: Copy) {
-                from { configurations.compile }
-                into { "${project.projectDir}/libs" }
-            }
+                // Copy JAR dependencies into the libs directory for Eclipse.
+                task deployLibs(type: Copy) {
+                    from { configurations.compile }
+                    into { "${project.projectDir}/libs" }
+                }
 
-            // Exclude a few files that are duplicated across our dependencies and
-            // prevent packaging Android applications.
-            packagingOptions {
-                /* https://github.com/rosjava/android_core/issues/194 */
-                exclude "META-INF/LICENSE.txt"
-                exclude "META-INF/NOTICE.txt"
+                // Exclude a few files that are duplicated across our dependencies and
+                // prevent packaging Android applications.
+                packagingOptions {
+                    /* https://github.com/rosjava/android_core/issues/194 */
+                    exclude "META-INF/LICENSE.txt"
+                    exclude "META-INF/NOTICE.txt"
+                    exclude 'META-INF/gradle-plugins/catkin.properties'
+                    exclude 'META-INF/gradle-plugins/ros.properties'
+                    exclude 'META-INF/gradle-plugins/ros-android.properties'
+                    exclude 'META-INF/gradle-plugins/ros-java.properties'
+                }
             }
         }
     }
 }
 
-defaultTasks 'assembleRelease', 'uploadArchives'
+defaultTasks 'assembleRelease', 'uploadArchives', 'publishMavenJavaPublicationToMavenRepository'

--- a/compressed_map_transport/build.gradle
+++ b/compressed_map_transport/build.gradle
@@ -14,27 +14,10 @@
  * the License.
  */
 
-group 'ros.android_core'
-version = '0.0.0-SNAPSHOT'
+version = '0.0.0'
 
-apply plugin: 'java'
-apply plugin: 'eclipse'
-apply plugin: 'maven'
-apply plugin: 'application'
-
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
-
-mainClassName = 'org.ros.RosRun'
-
-repositories {
-  mavenLocal()
-  maven {
-    url 'http://robotbrains.hideho.org/nexus/content/groups/ros-public'
-  }
-}
+apply plugin: 'ros-java'
 
 dependencies {
-  compile 'ros.rosjava_core:rosjava:0.0.0-SNAPSHOT'
+  compile 'org.ros.rosjava_core:rosjava:[0.2,0.3)'
 }
-

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -18,7 +18,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 task javadoc(type: Javadoc) {
   def javaProjects = rootProject.subprojects.findResults {
-    (it.name != 'docs') ? it : null
+    (it.name != 'docs' && it.name !="polling_input_stream") ? it : null
   }
   source javaProjects.collect { fileTree(dir: "${it.projectDir}/src/main/java") }
   classpath = files(javaProjects.collect { it.configurations.compile })
@@ -42,7 +42,4 @@ task clean << {
   ant.delete file: 'src/main/sphinx/conf.py'
 }
 
-/* Dummy task to stop android studio barfing */
-task assembleDebug {}
-task assembleRelease {}
-task assemble {}
+

--- a/polling_input_stream/build.gradle
+++ b/polling_input_stream/build.gradle
@@ -14,25 +14,11 @@
  * the License.
  */
 
-group 'ros.android_core'
-version = '0.0.0-SNAPSHOT'
+version = '0.0.0'
 
-apply plugin: 'java'
-apply plugin: 'eclipse'
-apply plugin: 'maven'
-
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
-
-repositories {
-  mavenLocal()
-  maven {
-    url 'http://robotbrains.hideho.org/nexus/content/groups/ros-public'
-  }
-}
+apply plugin: 'ros-java'
 
 dependencies {
-  compile 'ros.rosjava_core:rosjava:0.0.0-SNAPSHOT'
-  testCompile 'junit:junit:4.8.2'
+    compile 'org.ros.rosjava_core:rosjava:[0.2,0.3)'
+    testCompile 'junit:junit:4.8.2'
 }
-

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,5 +28,5 @@ include "docs"
 // TODO(damonkohler): The following projects are not included in the
 // multi-project yet till its sorted whereabouts they should actually live
 // (should they be in a java repo instead?)
-// include "compressed_map_transport"
-// include "polling_input_stream"
+include "compressed_map_transport"
+include "polling_input_stream"


### PR DESCRIPTION
- revieve from graveyard compressed_map_transport, polling_input_stream
- add excluded files from [gradle-plugins](https://github.com/rosjava/rosjava_bootstrap/tree/indigo/gradle_plugins/src/main/resources/META-INF/gradle-plugins), that can compile with catkin_make.
- issue polling_input_stream can compile with docs fix with workaround
- can add any project to android_core, not have to start with android_*
- remove dummy tasks at docs
