### PR TITLE
Make the LocalBinder class public

### DIFF
--- a/android_10/src/org/ros/android/NodeMainExecutorService.java
+++ b/android_10/src/org/ros/android/NodeMainExecutorService.java
@@ -63,10 +63,10 @@ public class NodeMainExecutorService extends Service implements NodeMainExecutor
   // NOTE(damonkohler): If this is 0, the notification does not show up.
   private static final int ONGOING_NOTIFICATION = 1;
 
-  static final String ACTION_START = "org.ros.android.ACTION_START_NODE_RUNNER_SERVICE";
-  static final String ACTION_SHUTDOWN = "org.ros.android.ACTION_SHUTDOWN_NODE_RUNNER_SERVICE";
-  static final String EXTRA_NOTIFICATION_TITLE = "org.ros.android.EXTRA_NOTIFICATION_TITLE";
-  static final String EXTRA_NOTIFICATION_TICKER = "org.ros.android.EXTRA_NOTIFICATION_TICKER";
+  public static final String ACTION_START = "org.ros.android.ACTION_START_NODE_RUNNER_SERVICE";
+  public static final String ACTION_SHUTDOWN = "org.ros.android.ACTION_SHUTDOWN_NODE_RUNNER_SERVICE";
+  public static final String EXTRA_NOTIFICATION_TITLE = "org.ros.android.EXTRA_NOTIFICATION_TITLE";
+  public static final String EXTRA_NOTIFICATION_TICKER = "org.ros.android.EXTRA_NOTIFICATION_TICKER";
 
   private final NodeMainExecutor nodeMainExecutor;
   private final IBinder binder;

--- a/android_10/src/org/ros/android/NodeMainExecutorService.java
+++ b/android_10/src/org/ros/android/NodeMainExecutorService.java
@@ -83,8 +83,8 @@ public class NodeMainExecutorService extends Service implements NodeMainExecutor
    * Class for clients to access. Because we know this service always runs in
    * the same process as its clients, we don't need to deal with IPC.
    */
-  class LocalBinder extends Binder {
-    NodeMainExecutorService getService() {
+  public class LocalBinder extends Binder {
+    public NodeMainExecutorService getService() {
       return NodeMainExecutorService.this;
     }
   }


### PR DESCRIPTION
Made the LocalBinder class and getService() method public so they can be used outside of RosActivity.

Fixes #238
