### PR TITLE
Makes the android studio manifest merger not require the use of a tools:replace="android:icon"

### DIFF
--- a/android_10/AndroidManifest.xml
+++ b/android_10/AndroidManifest.xml
@@ -11,9 +11,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
-    <application
-        android:icon="@mipmap/icon"
-        android:label="@string/app_name">
+    <application>
         <activity
             android:name="org.ros.android.MasterChooser"
             android:label="@string/app_name"


### PR DESCRIPTION
Removes label and icon from application tag in android_10's manifest file.  Makes the android studio manifest merger not require the use of
a tools:replace="android:icon" call for using a personal icons.  Makes
use of library projects less problematic as double opening of application tag causes conflict between icons even when that library project does not have an icon set.
