### PR TITLE
Update vertex buffer limit.

### DIFF
--- a/android_15/src/org/ros/android/view/visualization/layer/LaserScanLayer.java
+++ b/android_15/src/org/ros/android/view/visualization/layer/LaserScanLayer.java
@@ -86,6 +86,7 @@ public class LaserScanLayer extends SubscriberLayer<sensor_msgs.LaserScan> imple
   }
 
   private void updateVertexBuffer(LaserScan laserScan, int stride) {
+    int vertexCount = 0;
     float[] ranges = laserScan.getRanges();
     int size = ((ranges.length / stride) + 2) * 3;
     if (vertexBackBuffer == null || vertexBackBuffer.capacity() < size) {
@@ -96,6 +97,7 @@ public class LaserScanLayer extends SubscriberLayer<sensor_msgs.LaserScan> imple
     vertexBackBuffer.put(0);
     vertexBackBuffer.put(0);
     vertexBackBuffer.put(0);
+    vertexCount++;
     float minimumRange = laserScan.getRangeMin();
     float maximumRange = laserScan.getRangeMax();
     float angle = laserScan.getAngleMin();
@@ -111,10 +113,12 @@ public class LaserScanLayer extends SubscriberLayer<sensor_msgs.LaserScan> imple
         vertexBackBuffer.put((float) (range * Math.cos(angle)));
         vertexBackBuffer.put((float) (range * Math.sin(angle)));
         vertexBackBuffer.put(0);
+        vertexCount++;
       }
       angle += angleIncrement * stride;
     }
     vertexBackBuffer.position(0);
+    vertexBackBuffer.limit(vertexCount * 3);
     synchronized (mutex) {
       FloatBuffer tmp = vertexFrontBuffer;
       vertexFrontBuffer = vertexBackBuffer;


### PR DESCRIPTION
This PR fixes the problem reported in #251.
Updates the limit of the vertex buffer to reflect the new point count. Otherwise we were using old data.

Before fix:
rviz ground truth:
![screenshot from 2017-02-21 17 15 19](https://cloud.githubusercontent.com/assets/9289769/23184870/2841d610-f860-11e6-88e6-a4a6acca4604.png)
android laserscan artifacts visible:
![screenshot_2017-02-21-17-15-14](https://cloud.githubusercontent.com/assets/9289769/23184884/33fe6234-f860-11e6-91d7-dd388c37b2b6.png)

After fix:
rviz ground truth:
![screenshot from 2017-02-21 17 11 12](https://cloud.githubusercontent.com/assets/9289769/23184923/54838520-f860-11e6-94bc-cc8155889b57.png)
android laserscan clean:
![screenshot_2017-02-21-17-09-26](https://cloud.githubusercontent.com/assets/9289769/23184949/6551946e-f860-11e6-8c21-f8c6388b0f14.png)

