### PR TITLE
Adds capability to remember recent hosts.

### DIFF
--- a/android_10/res/layout/master_chooser.xml
+++ b/android_10/res/layout/master_chooser.xml
@@ -18,7 +18,7 @@
             android:text="@string/uri_text"
             android:textSize="18dp"/>
 
-        <EditText
+        <AutoCompleteTextView
             android:id="@+id/master_chooser_uri"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -27,7 +27,7 @@
             android:singleLine="true">
 
             <requestFocus/>
-        </EditText>
+        </AutoCompleteTextView>
     </LinearLayout>
 
     <LinearLayout

--- a/android_10/src/org/ros/android/MasterChooser.java
+++ b/android_10/src/org/ros/android/MasterChooser.java
@@ -372,14 +372,15 @@ public class MasterChooser extends Activity {
   }
 
   /**
-   * Stores the recent Master URI to preferences. This implementation does not use
+   * Adds the given URI to the list of recent Master URIs stored in shared preferences.
+   * This implementation does not use
    * {@link android.content.SharedPreferences.Editor#putStringSet(String, Set)}
    * since it is not available in API 10.
    * @param uri Master URI string to store.
    */
-  private void setRecentMasterURI(String uri)  {
+  private void setRecentMasterURI(String uri) {
     List<String> recentURIs = getRecentMasterURIs();
-    if(!recentURIs.contains(uri)){
+    if(!recentURIs.contains(uri)) {
       recentURIs.add(0, uri);
       if(recentURIs.size() > RECENT_MASTER_HISTORY_COUNT)
         recentURIs = recentURIs.subList(0, RECENT_MASTER_HISTORY_COUNT);
@@ -387,16 +388,16 @@ public class MasterChooser extends Activity {
 
     SharedPreferences.Editor editor = getPreferences(MODE_PRIVATE).edit();
     editor.putString(PREFS_KEY_NAME, uri);
-    for(int i=0; i<recentURIs.size(); i++)
-    {
+    for(int i=0; i<recentURIs.size(); i++) {
       editor.putString(RECENT_PREFIX_KEY_NAME + String.valueOf(i), recentURIs.get(i));
     }
+
     editor.putInt(RECENT_COUNT_KEY_NAME, recentURIs.size());
     editor.apply();
   }
 
   /**
-   * Gets a list of recent Master URIs from preferences. This implementation does not use
+   * Gets a list of recent Master URIs from shared preferences. This implementation does not use
    * {@link android.content.SharedPreferences.Editor#putStringSet(String, Set)}
    * since it is not available in API 10.
    * @return List of recent Master URI strings
@@ -408,10 +409,11 @@ public class MasterChooser extends Activity {
     recentURIs = new ArrayList<>(numRecent);
     for(int i=0; i<numRecent; i++) {
       String uri = prefs.getString(RECENT_PREFIX_KEY_NAME + String.valueOf(i), "");
-      if(!uri.isEmpty()){
+      if(!uri.isEmpty()) {
         recentURIs.add(uri);
       }
     }
+
     return recentURIs;
   }
 

--- a/android_10/src/org/ros/android/MasterChooser.java
+++ b/android_10/src/org/ros/android/MasterChooser.java
@@ -33,7 +33,6 @@ import android.view.View;
 import android.widget.AutoCompleteTextView;
 import android.widget.Button;
 import android.widget.CheckBox;
-import android.widget.EditText;
 import android.widget.Toast;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
@@ -46,16 +45,13 @@ import org.ros.internal.node.xmlrpc.XmlRpcTimeoutException;
 import org.ros.namespace.GraphName;
 import org.ros.node.NodeConfiguration;
 
-import java.lang.reflect.Array;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -284,7 +280,7 @@ public class MasterChooser extends Activity {
       protected void onPostExecute(Boolean result) {
         if (result) {
           //Update Recent Master URI
-          setRecentMasterURI(uri);
+          addRecentMasterURI(uri);
           // If the displayed URI is valid then pack that into the intent.
           // Package the intent to be consumed by the calling activity.
           Intent intent = createNewMasterIntent(false, true);
@@ -378,17 +374,17 @@ public class MasterChooser extends Activity {
    * since it is not available in API 10.
    * @param uri Master URI string to store.
    */
-  private void setRecentMasterURI(String uri) {
+  private void addRecentMasterURI(String uri) {
     List<String> recentURIs = getRecentMasterURIs();
-    if(!recentURIs.contains(uri)) {
+    if (!recentURIs.contains(uri)) {
       recentURIs.add(0, uri);
-      if(recentURIs.size() > RECENT_MASTER_HISTORY_COUNT)
+      if (recentURIs.size() > RECENT_MASTER_HISTORY_COUNT)
         recentURIs = recentURIs.subList(0, RECENT_MASTER_HISTORY_COUNT);
     }
 
     SharedPreferences.Editor editor = getPreferences(MODE_PRIVATE).edit();
     editor.putString(PREFS_KEY_NAME, uri);
-    for(int i=0; i<recentURIs.size(); i++) {
+    for (int i = 0; i < recentURIs.size(); i++) {
       editor.putString(RECENT_PREFIX_KEY_NAME + String.valueOf(i), recentURIs.get(i));
     }
 
@@ -402,14 +398,14 @@ public class MasterChooser extends Activity {
    * since it is not available in API 10.
    * @return List of recent Master URI strings
    */
-  private List<String> getRecentMasterURIs()  {
+  private List<String> getRecentMasterURIs() {
     List<String> recentURIs;
     SharedPreferences prefs = getPreferences(MODE_PRIVATE);
     int numRecent = prefs.getInt(RECENT_COUNT_KEY_NAME, 0);
     recentURIs = new ArrayList<>(numRecent);
-    for(int i=0; i<numRecent; i++) {
+    for (int i = 0; i < numRecent; i++) {
       String uri = prefs.getString(RECENT_PREFIX_KEY_NAME + String.valueOf(i), "");
-      if(!uri.isEmpty()) {
+      if (!uri.isEmpty()) {
         recentURIs.add(uri);
       }
     }


### PR DESCRIPTION
Adds capability to remember recent hosts. When entering the Master URI a list of recent Master URIs is presented. This implements the Remember recent hosts task in rosjava/android_core#257.
- [X] Remember recent hosts (useful when changing masters)