### PR TITLE
MasterChooser onBackPressed Pause

### DIFF
--- a/android_10/src/org/ros/android/MasterChooser.java
+++ b/android_10/src/org/ros/android/MasterChooser.java
@@ -207,6 +207,12 @@ public class MasterChooser extends Activity {
     }
   }
 
+  @Override
+  public void onBackPressed() {
+    //Prevent user from going back to Launcher Activity since no Master is connected.
+    toast("Please connect to a Master!");
+  }
+
   public void okButtonClicked(View unused) {
     String tmpURI = uriText.getText().toString();
 

--- a/android_10/src/org/ros/android/MasterChooser.java
+++ b/android_10/src/org/ros/android/MasterChooser.java
@@ -210,7 +210,7 @@ public class MasterChooser extends Activity {
   @Override
   public void onBackPressed() {
     //Prevent user from going back to Launcher Activity since no Master is connected.
-    toast("Please connect to a Master!");
+    this.moveTaskToBack(true);
   }
 
   public void okButtonClicked(View unused) {


### PR DESCRIPTION
The ROS application is "paused" when the user navigates back from the MasterChooser application. This fixes #266.