### PR TITLE
Added simple toast to notify user when a new interface has been selected.

### DIFF
--- a/android_10/src/org/ros/android/MasterChooser.java
+++ b/android_10/src/org/ros/android/MasterChooser.java
@@ -180,6 +180,7 @@ public class MasterChooser extends Activity {
       @Override
       public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
         selectedInterface = parent.getItemAtPosition(position).toString();
+        toast("Using " + selectedInterface + " interface.");
       }
     });
 


### PR DESCRIPTION
This feature falls within the purpose of #257. Now when a user selects a new interface from the advanced options a toast message is displayed. On some versions of android, the listview item has not UI effect when selected so this provides feedback to the user that new interface has been selected.