### PR TITLE
Don't draw pixels that don't come in messages

### DIFF
--- a/android_15/src/org/ros/android/view/visualization/layer/OccupancyGridLayer.java
+++ b/android_15/src/org/ros/android/view/visualization/layer/OccupancyGridLayer.java
@@ -55,6 +55,11 @@ public class OccupancyGridLayer extends SubscriberLayer<nav_msgs.OccupancyGrid> 
   private static final int COLOR_UNKNOWN = 0xffdddddd;
 
   /**
+   * Color of transparent cells in the map.
+   */
+  private static final int COLOR_TRANSPARENT = 0x00000000;
+
+  /**
    * In order to draw maps with a size outside the maximum size of a texture,
    * we split the map into multiple tiles and draw one texture per tile.
    */
@@ -105,7 +110,7 @@ public class OccupancyGridLayer extends SubscriberLayer<nav_msgs.OccupancyGrid> 
     public void update() {
       Preconditions.checkNotNull(origin);
       Preconditions.checkNotNull(stride);
-      textureBitmap.updateFromPixelBuffer(pixelBuffer, stride, resolution, origin, COLOR_UNKNOWN);
+      textureBitmap.updateFromPixelBuffer(pixelBuffer, stride, resolution, origin, COLOR_TRANSPARENT);
       pixelBuffer.clear();
       ready = true;
     }


### PR DESCRIPTION
Tiles in the OccupancyGridLayer were painting pixels beyond the data from occupancy grid messages as "unknown area" (gray).
This was misleading, since it was drawing data that was not really coming in the corresponding ROS message, and it also prevented this layer to properly be used on top of other layers if the message data was smaller than the tile size (it was overlaying the layer below with gray)