### PR TITLE
Moving google maven definition to public buildscript.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,14 +20,6 @@ task wrapper(type: Wrapper) {
 
 buildscript {
     apply from: project.file("buildscript.gradle")
-    allprojects {
-        repositories {
-            jcenter()
-            maven {
-                url "https://maven.google.com"
-            }
-        }
-    }
 }
 
 apply plugin: "catkin"

--- a/buildscript.gradle
+++ b/buildscript.gradle
@@ -19,4 +19,13 @@ rootProject.buildscript {
   dependencies {
     classpath "com.android.tools.build:gradle:3.2.1"
   }
+
+  allprojects {
+    repositories {
+      jcenter()
+      maven {
+        url "https://maven.google.com"
+      }
+    }
+  }
 }


### PR DESCRIPTION
This allows building `android_remocons` and `android_apps` properly.