### PR TITLE
fix for OccupancyGridLayer

### DIFF
--- a/android_core_components/src/org/ros/android/view/visualization/layer/OccupancyGridLayer.java
+++ b/android_core_components/src/org/ros/android/view/visualization/layer/OccupancyGridLayer.java
@@ -191,11 +191,7 @@ public class OccupancyGridLayer extends SubscriberLayer<nav_msgs.OccupancyGrid> 
         tiles.get(tileIndex).setOrigin(origin.multiply(new Transform(new Vector3(x *
             resolution * TextureBitmap.STRIDE,
             y * resolution * TextureBitmap.HEIGHT, 0.), Quaternion.identity())));
-        if (x < numTilesWide - 1) {
-          tiles.get(tileIndex).setStride(TextureBitmap.STRIDE);
-        } else {
-          tiles.get(tileIndex).setStride(width % TextureBitmap.STRIDE);
-        }
+        tiles.get(tileIndex).setStride(TextureBitmap.STRIDE);
       }
     }
 


### PR DESCRIPTION
PR regarding [this issue](https://github.com/rosjava/android_core/issues/297).

Before (I changed the COLOR_TRANSPARENT to 0x55FF0000 for better visibility of the 'error'):

![occupancy_error_0x55FF0000](https://user-images.githubusercontent.com/32774990/55731445-8778c800-5a1a-11e9-8eab-52219e85e580.png)

After:

![proper_occupancy_map](https://user-images.githubusercontent.com/32774990/55731476-96f81100-5a1a-11e9-9cb4-c2f444e119e2.png)
