### PR TITLE
Changed GL_LINES to GL_LINE_STRIP inside drawLines method

### DIFF
--- a/android_core_components/src/org/ros/android/view/visualization/Vertices.java
+++ b/android_core_components/src/org/ros/android/view/visualization/Vertices.java
@@ -86,7 +86,7 @@ public class Vertices {
     gl.glLineWidth(width);
     gl.glEnableClientState(GL10.GL_VERTEX_ARRAY);
     gl.glVertexPointer(3, GL10.GL_FLOAT, 0, vertices);
-    gl.glDrawArrays(GL10.GL_LINES, 0, countVertices(vertices, 3));
+    gl.glDrawArrays(GL10.GL_LINE_STRIP, 0, countVertices(vertices, 3));
     gl.glDisableClientState(GL10.GL_VERTEX_ARRAY);
     vertices.reset();
   }


### PR DESCRIPTION
Related to [this issue](https://github.com/rosjava/android_core/issues/305)

`GL_LINES` only draws a line between every two vertices while `GL_LINE_STRIP` draws a line between every specified vertex. [Link to documentation.](https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glBegin.xml)

I've attached two pictures to show a comparison:

GL_LINES:
![lines](https://user-images.githubusercontent.com/32774990/58479369-74e85880-8158-11e9-94e4-3d70126820ba.png)

GL_LINE_STRIP:
![line_strip](https://user-images.githubusercontent.com/32774990/58479389-82054780-8158-11e9-8461-9dc9ef38ef99.png)

While the `GL_LINE_STRIP` version still looks a little bit off at some parts, probably due to missing anti aliasing, it's definitly an improvement to the current version.