### PR TITLE
Buildscript update

### DIFF
--- a/buildscript.gradle
+++ b/buildscript.gradle
@@ -17,7 +17,7 @@
 rootProject.buildscript {
   apply from: "https://github.com/rosjava/rosjava_bootstrap/raw/kinetic/buildscript.gradle"
   dependencies {
-    classpath "com.android.tools.build:gradle:3.2.1"
+    classpath "com.android.tools.build:gradle:3.5.2"
   }
 
   allprojects {

--- a/buildscript.gradle
+++ b/buildscript.gradle
@@ -22,10 +22,8 @@ rootProject.buildscript {
 
   allprojects {
     repositories {
+      google()
       jcenter()
-      maven {
-        url "https://maven.google.com"
-      }
     }
   }
 }


### PR DESCRIPTION
- Updating Android Gradle plugin: 3.2.1 --> 3.5.2.
- Adding Google to repositories at the top (see [ref](https://developers.google.com/sceneform/develop/getting-started#configure-project)).